### PR TITLE
feat: add approval checkbox format to spec workflow commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Approval Checkbox Format**: Commands now instruct to add `✅ APPROVED` marker when phases are approved
+  - Updated all spec commands to include approval marker instructions
+  - Added placeholder comments in templates for approval markers
+  - Ensures consistent approval tracking across all phases
+
 ## [1.3.0] - 2025-07-24
 
 ### Added

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -41,6 +41,7 @@ You are helping create a new feature specification. Follow these steps:
    - **Include codebase analysis summary**: Briefly note what existing code can be leveraged
    - Ask: "Do the requirements look good? If so, we can move on to the design."
    - Wait for explicit approval before proceeding
+   - When user approves, add \`✅ APPROVED\` at the end of the requirements.md file
 
 6. **Complete Requirements Phase**
    - Present the requirements document with reuse opportunities highlighted
@@ -102,6 +103,7 @@ You are working on the requirements phase of the spec workflow.
    - Ask: "Do the requirements look good? If so, we can move on to the design."
    - Make revisions based on feedback
    - Continue until explicit approval is received
+   - When user approves, add \`✅ APPROVED\` at the end of the requirements.md file
 
 ## Requirements Format
 \`\`\`markdown
@@ -176,6 +178,7 @@ You are working on the design phase of the spec workflow.
    - Ask: "Does the design look good? If so, we can move on to the implementation plan."
    - Incorporate feedback and revisions
    - Continue until explicit approval
+   - When user approves, add \`✅ APPROVED\` at the end of the design.md file
 
 ## Design Structure
 \`\`\`markdown
@@ -266,6 +269,7 @@ You are working on the tasks phase of the spec workflow.
    - Ask: "Do the tasks look good?"
    - Make revisions based on feedback
    - Continue until explicit approval
+   - When user approves, add \`✅ APPROVED\` at the end of the tasks.md file
 
 7. **Generate Task Commands** (ONLY after tasks approval)
    - **WAIT**: Do not run script until user explicitly approves tasks

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -39,6 +39,10 @@ export function getRequirementsTemplate(): string {
 
 ### Usability
 - [Usability requirements]
+
+---
+
+<!-- Approval marker will be added here when approved -->
 `;
 }
 
@@ -114,6 +118,10 @@ interface Model2 {
 ### End-to-End Testing
 - [E2E testing approach]
 - [User scenarios to test]
+
+---
+
+<!-- Approval marker will be added here when approved -->
 `;
 }
 
@@ -195,5 +203,9 @@ export function getTasksTemplate(): string {
   - Fix any integration issues
   - Clean up code and documentation
   - _Requirements: All_
+
+---
+
+<!-- Approval marker will be added here when approved -->
 `;
 }


### PR DESCRIPTION
## Summary
This PR adds explicit instructions for adding approval markers to spec documents, ensuring consistent approval tracking across the workflow.

## Changes
- Updated all spec command templates to instruct users to add `✅ APPROVED` marker when phases are approved
- Added placeholder comments in document templates indicating where approval markers should be placed
- Updated CHANGELOG.md to document this enhancement

## Motivation
Currently, the dashboard parser looks for `✅ APPROVED` markers to track phase completion, but the commands don't explicitly instruct users to add these markers. This can lead to confusion about how to properly mark phases as approved.

This change makes the approval process explicit and ensures consistent formatting across all projects using the spec workflow.

## Implementation Details
1. **src/commands.ts** - Added approval marker instructions to:
   - `spec-create` command (requirements phase)
   - `spec-requirements` command
   - `spec-design` command  
   - `spec-tasks` command

2. **src/templates.ts** - Added placeholder comments at the end of each template:
   ```markdown
   ---
   
   <\!-- Approval marker will be added here when approved -->
   ```

3. **CHANGELOG.md** - Documented the change in the Unreleased section

## Testing
- Built project successfully with `npm run build`
- All existing tests pass with `npm test`
- No breaking changes - this only adds instructions to command templates

## Backwards Compatibility
This change is fully backwards compatible. It only adds instructions and comments, without changing any existing functionality or file formats.

🤖 Generated with [Claude Code](https://claude.ai/code)